### PR TITLE
- Fixed directory name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This work relies on the previous repo for exponential maximum pooling (**[alexan
 You can build the repo through the following commands:
 ```
 $ git clone https://github.com/alexandrosstergiou/adaPool.git
-$ cd adaPool-master/pytorch
+$ cd adaPool/pytorch
 $ make install
 --- (optional) ---
 $ make test


### PR DESCRIPTION
   adaPool-master --> adaPool
 On branch main
 Your branch is up to date with 'origin/main'.

 Changes to be committed:
	modified:   README.md